### PR TITLE
Do not block while blinking

### DIFF
--- a/lib/scsi2sd/led.h
+++ b/lib/scsi2sd/led.h
@@ -16,9 +16,12 @@
 //	along with SCSI2SD.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef S2S_LED_H
 #define S2S_LED_H
+#include <stdint.h>
 
 void s2s_ledInit(void);
 void s2s_ledOn(void);
 void s2s_ledOff(void);
-
+void s2s_ledBlink(uint8_t times, uint32_t delay, uint32_t end_delay);
+uint8_t s2s_ledBlinkPoll();
+void s2s_blinkCancel();
 #endif

--- a/lib/scsi2sd/main.c
+++ b/lib/scsi2sd/main.c
@@ -141,6 +141,7 @@ void mainLoop()
     scsiPoll();
     scsiDiskPoll();
     s2s_configPoll();
+    s2s_ledBlinkPoll();
 
 #ifdef S2S_USB_FS
     int usbBusy = s2s_usbDevicePoll(&hUsbDeviceFS);

--- a/lib/scsi2sd/sd.c
+++ b/lib/scsi2sd/sd.c
@@ -225,6 +225,7 @@ int sdInit()
 
         if (cs && !(blockDev.state & DISK_PRESENT))
         {
+            s2s_blinkCancel();
             s2s_ledOn();
 
             // Debounce. Quicker if the card is present at
@@ -289,17 +290,8 @@ int sdInit()
     }
     if (!(blockDev.state & (DISK_PRESENT | DISK_INITIALISED)))
     {
-
-     for (int i = 0; i < 5; ++i)
-        {
-            // visual indicator for no SD card
-            s2s_ledOff();
-            s2s_delay_ms(250);
-            s2s_ledOn();
-            s2s_delay_ms(250);
-        }
-        s2s_ledOff();
-        s2s_delay_ms(500);
+        // visual indicator for no SD card
+        s2s_ledBlink(5, 500, 1000);
     }
     firstInit = 0;
 


### PR DESCRIPTION
This addresses an issue when the no SD card blinks and the ZuluSCSI V6 Util is open. Before it would cause the Util to freeze while the LEDs was blinking. Now it does not.

Added the ability to blink without blocking
Requires a polling function in the main loop
Added the ability to cancel blinking
While the LED is blinking disable other LED on or off request